### PR TITLE
Fix error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
-pub fn fetch_one_row<F, T, E>(mut m: rusqlite::MappedRows<F>) -> Result<T, E>
+use rusqlite::Result;
+
+pub fn fetch_one_row<F, T>(mut m: rusqlite::MappedRows<F>) -> Result<T>
 where
-    F: FnMut(&rusqlite::Row<'_>) -> Result<T, E>,
+    F: FnMut(&rusqlite::Row<'_>) -> Result<T>,
 {
     m.next().unwrap()
 }


### PR DESCRIPTION
This resolves the error that rustc claims iterator is not implemented for the `rusqlite::MappedRows` type:

```
error[E0599]: no method named `next` found for type `rusqlite::row::MappedRows<'_, F>` in the current scope
 --> src/main.rs:5:7
  |
5 |     m.next().unwrap()
  |       ^^^^
  |
  = note: the method `next` exists but the following trait bounds were not satisfied:
          `rusqlite::row::MappedRows<'_, F> : std::iter::Iterator`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: Could not compile `iterators`.

To learn more, run the command again with --verbose.
```